### PR TITLE
Popravil RandomMoveChoser

### DIFF
--- a/src/inteligenca/RandomMoveChooser.java
+++ b/src/inteligenca/RandomMoveChooser.java
@@ -16,7 +16,7 @@ public class RandomMoveChooser extends MoveChooser {
 	@Override
 	public Poteza chooseMove(Igra igra) {
 		List<Poteza> validMoves = igra.validMoves();
-		int idx = rng.nextInt() % validMoves.size();
+		int idx = Math.abs(rng.nextInt()) % validMoves.size();
 		return validMoves.get(idx);
 	}
 


### PR DESCRIPTION
V Javi se lahko zgodi, da je ostanek pri deljenju ( operacija `%`) lahko negativen, zato če hočemo z njim naključno izbrati element seznama moramo zagotoviti, da bo dobljeno število pozitivno.